### PR TITLE
Add persistent index cache

### DIFF
--- a/imgstore/__init__.py
+++ b/imgstore/__init__.py
@@ -5,4 +5,4 @@ from .util import ensure_color, ensure_grayscale
 
 test = main_test
 
-__version__ = '0.2.9'
+__version__ = '0.3.0'

--- a/imgstore/constants.py
+++ b/imgstore/constants.py
@@ -1,0 +1,19 @@
+try:
+    # python 3
+    # noinspection PyProtectedMember
+    from subprocess import DEVNULL
+    # noinspection PyShadowingBuiltins
+    xrange = range
+except ImportError:
+    # python 2
+    import os
+    DEVNULL = open(os.devnull, 'r+b')
+
+STORE_MD_KEY = '__store'
+STORE_MD_FILENAME = 'metadata.yaml'
+STORE_LOCK_FILENAME = '.lock'
+
+EXTRA_DATA_FILE_EXTENSIONS = ('.extra.json', '.extra_data.json', '.extra_data.h5')
+
+FRAME_MD = ('frame_number', 'frame_time')
+

--- a/imgstore/constants.py
+++ b/imgstore/constants.py
@@ -12,6 +12,7 @@ except ImportError:
 STORE_MD_KEY = '__store'
 STORE_MD_FILENAME = 'metadata.yaml'
 STORE_LOCK_FILENAME = '.lock'
+STORE_INDEX_FILENAME = '.index.sqlite'
 
 EXTRA_DATA_FILE_EXTENSIONS = ('.extra.json', '.extra_data.json', '.extra_data.h5')
 

--- a/imgstore/index.py
+++ b/imgstore/index.py
@@ -100,6 +100,11 @@ class ImgStoreIndex(object):
 
         return cls(db)
 
+    @classmethod
+    def new_from_file(cls, path):
+        db = sqlite3.connect(path)
+        return cls(db)
+
     @staticmethod
     def _get_metadata(cur):
         md = {'frame_number': [], 'frame_time': []}
@@ -112,6 +117,16 @@ class ImgStoreIndex(object):
     def chunks(self):
         """ the number of non-empty chunks that contain images """
         return self._chunks
+
+    def to_file(self, path):
+        db = sqlite3.connect(path)
+        with db:
+            for line in self._conn.iterdump():
+                # let python handle the transactions
+                if line not in ('BEGIN;', 'COMMIT;'):
+                    db.execute(line)
+        db.commit()
+        db.close()
 
     def iter_chunks_and_paths(self):
         for n in self._chunks:

--- a/imgstore/index.py
+++ b/imgstore/index.py
@@ -1,0 +1,153 @@
+import os.path
+import sqlite3
+import logging
+import operator
+
+import yaml
+import numpy as np
+
+from .constants import FRAME_MD
+
+
+def _load_index(path_without_extension):
+    for extension in ('.npz', '.yaml'):
+        path = path_without_extension + extension
+        if os.path.exists(path):
+            if extension == '.yaml':
+                with open(path, 'rt') as f:
+                    dat = yaml.safe_load(f)
+                    return {k: dat[k] for k in FRAME_MD}
+            elif extension == '.npz':
+                with open(path, 'rb') as f:
+                    dat = np.load(f)
+                    return {k: dat[k].tolist() for k in FRAME_MD}
+
+    raise IOError('could not find index %s' % path_without_extension)
+
+
+# noinspection SqlNoDataSourceInspection,SqlDialectInspection,SqlResolve
+class ImgStoreIndex(object):
+
+    VERSION = '1'
+
+    log = logging.getLogger('imgstore.index')
+
+    def __init__(self, db=None):
+        self._conn = db
+
+        cur = self._conn.cursor()
+
+        cur.execute('SELECT value FROM index_information WHERE name = ?', ('version', ))
+        v, = cur.fetchone()
+        if v != self.VERSION:
+            raise IOError('incorrect index version: %s vs %s' % (v, self.VERSION))
+
+        cur.execute('SELECT COUNT(1) FROM frames')
+        self.frame_count, = cur.fetchone()
+
+        def _minmax(_s):
+            cur.execute('SELECT {} FROM frames;'.format(_s))
+            return cur.fetchone()[0]
+
+        if self.frame_count:
+            self.frame_time_max = _minmax('MAX(frame_time)')
+            self.frame_time_min = _minmax('MIN(frame_time)')
+            self.frame_max = _minmax('MAX(frame_number)')
+            self.frame_min = _minmax('MIN(frame_number)')
+        else:
+            self.frame_max = self.frame_min = np.nan
+            self.frame_time_max = self.frame_time_min = 0.0
+
+        self.log.debug('frame range %f -> %f' % (self.frame_min, self.frame_max))
+
+        # # all chunks in the store [0,1,2, ... ]
+        cur.execute('SELECT DISTINCT chunk FROM frames ORDER BY chunk;')
+        self._chunks = tuple(row[0] for row in cur)
+
+    @classmethod
+    def create_database(cls, conn):
+        c = conn.cursor()
+        # Create table
+        c.execute('CREATE TABLE frames '
+                  '(chunk INTEGER, chunk_path TEXT, frame_idx INTEGER, frame_number INTEGER, frame_time REAL)')
+        c.execute('CREATE TABLE index_information '
+                  '(name TEXT, value TEXT)')
+        c.execute('INSERT into index_information VALUES (?, ?)', ('version', cls.VERSION))
+        conn.commit()
+
+    @classmethod
+    def new_from_chunks(cls, chunk_n_and_chunk_paths):
+        db = sqlite3.connect(':memory:')
+        cls.create_database(db)
+
+        cur = db.cursor()
+
+        for chunk_n, chunk_path in sorted(chunk_n_and_chunk_paths, key=operator.itemgetter(0)):
+            try:
+                idx = _load_index(chunk_path)
+            except IOError:
+                cls.log.warn('missing index for chunk %s' % chunk_n)
+                continue
+
+            if not idx['frame_number']:
+                # empty chunk
+                continue
+
+            records = [(chunk_n, chunk_path, i, fn, ft) for i, (fn, ft) in enumerate(zip(idx['frame_number'],
+                                                                                         idx['frame_time']))]
+            cur.executemany('INSERT INTO frames VALUES (?,?,?,?,?)', records)
+            db.commit()
+
+        return cls(db)
+
+    @staticmethod
+    def _get_metadata(cur):
+        md = {'frame_number': [], 'frame_time': []}
+        for row in cur:
+            md['frame_number'].append(row[0])
+            md['frame_time'].append(row[1])
+        return md
+
+    @property
+    def chunks(self):
+        """ the number of non-empty chunks that contain images """
+        return self._chunks
+
+    def iter_chunks_and_paths(self):
+        for n in self._chunks:
+            cur = self._conn.cursor()
+            cur.execute("SELECT chunk_path FROM frames WHERE chunk = ? LIMIT 1;", (n, ))
+            yield n, cur.fetchone()[0]
+
+    def get_all_metadata(self):
+        cur = self._conn.cursor()
+        cur.execute("SELECT frame_number, frame_time FROM frames ORDER BY rowid;")
+        return self._get_metadata(cur)
+
+    def get_chunk_metadata(self, chunk_n):
+        cur = self._conn.cursor()
+        cur.execute("SELECT frame_number, frame_time FROM frames WHERE chunk = ? ORDER BY rowid;", (chunk_n, ))
+        return self._get_metadata(cur)
+
+    def find_chunk(self, what, value):
+        assert what in ('frame_number', 'frame_time', 'index')
+        cur = self._conn.cursor()
+
+        if what == 'index':
+            cur.execute("SELECT chunk, frame_idx FROM frames ORDER BY rowid LIMIT 1 OFFSET {};".format(int(value)))
+        else:
+            cur.execute("SELECT chunk, frame_idx FROM frames WHERE {} = ?;".format(what), (value, ))
+
+        try:
+            chunk_n, frame_idx = cur.fetchone()
+        except TypeError:  # no result
+            return -1, -1
+
+        return chunk_n, frame_idx
+
+    def find_chunk_nearest(self, what, value):
+        assert what in ('frame_number', 'frame_time')
+        cur = self._conn.cursor()
+        cur.execute("SELECT chunk, frame_idx FROM frames ORDER BY ABS(? - {}) LIMIT 1;".format(what), (value, ))
+        chunk_n, frame_idx = cur.fetchone()
+        return chunk_n, frame_idx

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     include_package_data=True,
-    version='0.2.9',
+    version='0.3.0',
     url='https://github.com/loopbio/imgstore',
     author='John Stowers, Santi Villalba',
     author_email='john@loopbio.com, santi@loopbio.com',


### PR DESCRIPTION
* adds a sqlite based index cache for faster reading of huge stores
* all tests pass
* doesn't change public API in a backwards incompatible way
  * adds `save_index=False` to `close()`
  * internal `_load_chunk_metadata` removed. Any derived backends should use `self._chunk_md = self._index.get_chunk_metadata(n)` instead
    