### PR TITLE
Changes to stop using pytz and tzlocal in order to deal with pytz deprecation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,7 @@ setup(
         'numpy',
         'pandas',
         'pyyaml',
-        'pytz',
-        'tzlocal',
+        'backports.zoneinfo; python_version < "3.9.0"',
         'python-dateutil',
     ],
     tests_require=[


### PR DESCRIPTION
Hey,

I made the changes required to stop using pytz and tzlocal, since with those libraries imgstore will stop working with python 3.10.
I am not sure that the changes are 100% correct, however, all the tests are passing. Feel free to make any changes.

