### PR TITLE
Fixes on previous PR related with obtaining the current timezone.

### DIFF
--- a/imgstore/stores.py
+++ b/imgstore/stores.py
@@ -13,6 +13,7 @@ import uuid
 import datetime
 import shutil
 import json
+import tzlocal
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
@@ -205,7 +206,7 @@ class _ImgStore(object):
                 except Exception:
                     pass
             if tz is None:
-                tz = ZoneInfo(datetime.datetime.now().astimezone().tzname())
+                tz = ZoneInfo(tzlocal.get_localzone_name())
 
             # first the filename
             m = re.match(r"""(.*)(20[\d]{6}_\d{6}).*""", os.path.basename(self._basedir))
@@ -268,7 +269,7 @@ class _ImgStore(object):
         self._uuid = uuid.uuid4().hex
         # because fuck you python that utcnow is naieve. kind of fixed in python >3.2
         self._created_utc = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
-        self._timezone_local = ZoneInfo(datetime.datetime.now().astimezone().tzname())
+        self._timezone_local = ZoneInfo(tzlocal.get_localzone_name())
 
         store_md = {'imgshape': write_imgshape,
                     'imgdtype': self._imgdtype,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     include_package_data=True,
-    version='0.3.1',
+    version='0.3.2',
     url='https://github.com/loopbio/imgstore',
     author='John Stowers, Santi Villalba',
     author_email='john@loopbio.com, santi@loopbio.com',
@@ -40,6 +40,7 @@ setup(
         'pandas',
         'pyyaml',
         'backports.zoneinfo; python_version < "3.9.0"',
+        'tzlocal',
         'python-dateutil',
     ],
     tests_require=[


### PR DESCRIPTION
Hey @nzjrs,

First, I am sorry, but I think I introduced a bug on this PR https://github.com/loopbio/imgstore/pull/25.

Here:

ZoneInfo(datetime.datetime.now().astimezone().tzname()) (both in line 208 and 271)

should be:

ZoneInfo(tzlocal.get_localzone_name())

And tzlocal should be added again as a dependency of the project.
If you need any help, please do not hesitate to contact me.